### PR TITLE
cleaning up stripping scripts

### DIFF
--- a/scripts/strip_linux_binary.sh
+++ b/scripts/strip_linux_binary.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 
 path=src/main/resources/org/graphlab/create/spark_unity_linux
 

--- a/scripts/strip_mac_binary.sh
+++ b/scripts/strip_mac_binary.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 path=src/main/resources/org/graphlab/create/spark_unity_mac
 
 strip -S $path


### PR DESCRIPTION
This minor changes moves the scripts used to strip the binaries to a scripts folder and attaches the correct header.

Change-Id: Ie93f57280695ab2ae400f2d49c70bd3639950e8c
